### PR TITLE
BLOXINF-1186: disactivate ui setting

### DIFF
--- a/config/vault-config.json
+++ b/config/vault-config.json
@@ -10,6 +10,5 @@
       "address": "[::]:8200",
       "tls_disable": 1
     }
-  },
-  "ui": true
+  }
 }


### PR DESCRIPTION
The Vault UI is not activated by default, so I removed the UI configuration option